### PR TITLE
Add Appveyor workflow to compile the mod/installer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,52 @@
+# AppVeyor CI configuration for Crysis VR Automated Build
+
+image:
+  - Visual Studio 2022
+
+version: '{build}'
+
+branches:
+  only:
+    - main
+
+skip_tags: false
+
+environment:
+  CRYSIS_INSTALL_DIR: $(APPVEYOR_BUILD_FOLDER)\installer\assembly
+
+build_script:
+  # Create required directories
+  - ps: mkdir installer\assembly -Force
+  # Build x64
+
+  - cmd: cd Code
+  - cmd: msbuild CrysisMod.sln /p:Configuration=Release /p:Platform=x64 -m
+  - cmd: cd ThirdParty\c1-launcher
+  - cmd: mkdir build64
+  - cmd: cd build64
+  - cmd: cmake -D CMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=x64 ..
+  - cmd: cmake --build . --parallel --config Release
+  - cmd: cd ..\..\..\..\
+  # Build Win32
+  - cmd: cd Code
+  - cmd: msbuild CrysisMod.sln /p:Configuration=Release /p:Platform=Win32 -m
+  - cmd: cd ThirdParty\c1-launcher
+  - cmd: mkdir build32
+  - cmd: cd build32
+  - cmd: cmake -D CMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=Win32 ..
+  - cmd: cmake --build . --parallel --config Release
+  - cmd: cd ..\..\..\..\
+  # Create installer
+  - cmd: echo %CD%
+  - cmd: cd installer
+  - cmd: create_installer.bat
+  - cmd: cd ..
+  # Zip debug symbols
+  - ps: if (Test-Path Bin64) { 7z a -t7z crysisvr_pdbs.7z Bin64\*.pdb }
+  - ps: if (Test-Path Bin32) { 7z a -t7z crysisvr_pdbs.7z Bin32\*.pdb }
+
+artifacts:
+  - path: installer\crysis-vrmod*.exe
+    name: installer
+  - path: crysisvr_pdbs.7z
+    name: pdbs


### PR DESCRIPTION
This should allow an alternative method to compile the mod in case there's any updates in the future since currently the [GitHub Actions workflow fails due to compilation errors](https://github.com/ThreeDeeJay/crysis_vrmod/actions/runs/15823087925/job/44596622611#step:5:781), as I mentioned in https://github.com/fholger/crysis_vrmod/issues/112#issuecomment-2770414600.
Just gotta link/login with the GitHub account on AppVeyor, add the repo via New Project and trigger a New Build.

![image](https://github.com/user-attachments/assets/14bfe32d-5c87-41f1-b666-8a1b76856c18)

Shoutout to GitHub Copilot for the first workflow transfer draft so I just had to fix some commands.
I haven't tested it thoroughly but there were no errors and the artifacts can be downloaded from here (they expire in a month):
https://ci.appveyor.com/api/buildjobs/6m1so2l658hnslea/artifacts/Installer%2Fcrysis-vrmod-1.1.1.exe