### PR TITLE
[#105] Fix compilation with VS2022 with recent (v143) compiler and stdlib

### DIFF
--- a/Code/CryEngine/CryCommon/VectorMap.h
+++ b/Code/CryEngine/CryCommon/VectorMap.h
@@ -56,7 +56,7 @@
 //
 //--------------------------------------------------------------------------
 
-template <typename K, typename V, typename T = std::less<K>, typename A = std::allocator<std::pair <const K, V> > >
+template <typename K, typename V, typename T = std::less<K>, typename A = std::allocator<std::pair <K, V> > >
 class VectorMap : private T // Empty base optimization
 {
 public:


### PR DESCRIPTION
This fixes an error where compiler cannot convert different `std::allocator<...>` where `const` is added unnecessarily, specifically in `Weapons.cpp` and `WeaponsSystem.cpp` on lines like:

```cpp
    m_StanceWeponOffset[curStance] = curOffset;
```

This was described in #105.